### PR TITLE
Fixes for Clang/GCC/Linux builds

### DIFF
--- a/MiniaudioCpp/include/MiniaudioCpp/CResource.h
+++ b/MiniaudioCpp/include/MiniaudioCpp/CResource.h
@@ -22,6 +22,7 @@
 #include <utility>
 #include <type_traits>
 #include <concepts>
+#include <cstring>
 
 namespace JPL::Internal
 {

--- a/MiniaudioCpp/include/MiniaudioCpp/Core.h
+++ b/MiniaudioCpp/include/MiniaudioCpp/Core.h
@@ -61,12 +61,12 @@
 #if defined(JPL_PLATFORM_WINDOWS)
 #define JPL_BREAKPOINT		__debugbreak()
 #elif defined(JPL_PLATFORM_LINUX) || defined(JPL_PLATFORM_ANDROID) || defined(JPL_PLATFORM_MACOS) || defined(JPL_PLATFORM_IOS) || defined(JPL_PLATFORM_FREEBSD)
-#if defined(JPL_CPU_X86)
+#ifdef __has_builtin
+#if __has_builtin(__builtin_trap)
+#define JPL_BREAKPOINT	__builtin_trap()
+#endif
+#elif defined(JPL_CPU_X86)
 #define JPL_BREAKPOINT	__asm volatile ("int $0x3")
-#elif defined(JPL_CPU_ARM)
-#define JPL_BREAKPOINT	__builtin_trap()
-#elif defined(JPL_CPU_E2K)
-#define JPL_BREAKPOINT	__builtin_trap()
 #endif
 #elif defined(JPL_PLATFORM_WASM)
 #define JPL_BREAKPOINT		do { } while (false) // Not supported

--- a/MiniaudioCpp/include/MiniaudioCpp/ErrorReporting.h
+++ b/MiniaudioCpp/include/MiniaudioCpp/ErrorReporting.h
@@ -35,14 +35,14 @@ using TraceFunction = void (*)(const char* message);
 JPL_EXPORT extern TraceFunction Trace;
 
 // Always turn on asserts in Debug mode
-#if defined(_DEBUG) && !defined(JPL_ENABLE_ASSERTS)
+#if !defined(NDEBUG) && !defined(JPL_ENABLE_ASSERTS)
 #define JPL_ENABLE_ASSERTS
 #ifndef JPL_TEST
 #define JPL_ENABLE_ENSURE
 #endif
 #endif
 
-#ifdef JPL_ENABLE_ASSERTS
+#if defined(JPL_ENABLE_ASSERTS) || defined(JPL_ENABLE_ENSURE)
 /// Function called when an assertion fails. This function should return true if a breakpoint needs to be triggered
 using AssertFailedFunction = bool(*)(const char* inExpression, const char* inMessage, const char* inFile, uint inLine);
 JPL_EXPORT extern AssertFailedFunction AssertFailed;
@@ -51,7 +51,9 @@ JPL_EXPORT extern AssertFailedFunction AssertFailed;
 struct AssertLastParam {};
 inline bool AssertFailedParamHelper(const char* inExpression, const char* inFile, uint inLine, AssertLastParam) { return AssertFailed(inExpression, nullptr, inFile, inLine); }
 inline bool AssertFailedParamHelper(const char* inExpression, const char* inFile, uint inLine, const char* inMessage, AssertLastParam) { return AssertFailed(inExpression, inMessage, inFile, inLine); }
+#endif
 
+#ifdef JPL_ENABLE_ASSERTS
 /// Main assert macro, usage: JPL_ASSERT(condition, message) or JPL_ASSERT(condition)
 #define JPL_ASSERT(inExpression, ...)	do { if (!(inExpression) && AssertFailedParamHelper(#inExpression, __FILE__, JPL::uint(__LINE__), ##__VA_ARGS__, JPL::AssertLastParam())) JPL_BREAKPOINT; } while (false)
 

--- a/MiniaudioCpp/src/MiniAudioInterface/ErrorReporting.cpp
+++ b/MiniaudioCpp/src/MiniAudioInterface/ErrorReporting.cpp
@@ -32,7 +32,7 @@ namespace JPL
 
 	TraceFunction Trace = DummyTrace;
 
-#ifdef JPL_ENABLE_ASSERTS
+#if defined(JPL_ENABLE_ASSERTS) || defined(JPL_ENABLE_ENSURE)
 
 	static bool DummyAssertFailed(const char* inExpression, const char* inMessage, const char* inFile, uint inLine)
 	{

--- a/MiniaudioCpp/src/MiniAudioInterface/MiniaudioWrappers.cpp
+++ b/MiniaudioCpp/src/MiniAudioInterface/MiniaudioWrappers.cpp
@@ -354,14 +354,14 @@ namespace JPL
 	{
 		ma_uint64 lengthPCFrames = 0;
 		ma_sound_get_length_in_pcm_frames(get(), &lengthPCFrames);
-		return (uint64_t) lengthPCFrames;
+		return static_cast<uint64_t>(lengthPCFrames);
 	}
 
 	uint64_t Sound::GetCursorInFrames()
 	{
 		ma_uint64 cursorPCMFrame = 0;
 		ma_sound_get_cursor_in_pcm_frames(get(), &cursorPCMFrame);
-		return (uint64_t) cursorPCMFrame;
+		return static_cast<uint64_t>(cursorPCMFrame);
 	}
 
 	float Sound::GetLengthInSeconds()

--- a/MiniaudioCpp/src/MiniAudioInterface/MiniaudioWrappers.cpp
+++ b/MiniaudioCpp/src/MiniAudioInterface/MiniaudioWrappers.cpp
@@ -352,16 +352,16 @@ namespace JPL
 
 	uint64_t Sound::GetLengthInFrames()
 	{
-		uint64_t lengthPCFrames = 0;
+		ma_uint64 lengthPCFrames = 0;
 		ma_sound_get_length_in_pcm_frames(get(), &lengthPCFrames);
-		return lengthPCFrames;
+		return (uint64_t) lengthPCFrames;
 	}
 
 	uint64_t Sound::GetCursorInFrames()
 	{
-		uint64_t cursorPCMFrame = 0;
+		ma_uint64 cursorPCMFrame = 0;
 		ma_sound_get_cursor_in_pcm_frames(get(), &cursorPCMFrame);
-		return cursorPCMFrame;
+		return (uint64_t) cursorPCMFrame;
 	}
 
 	float Sound::GetLengthInSeconds()


### PR DESCRIPTION
- Fix `ENSURE` requiring `AssertFailed` when it can be defined independent of `ENABLE_ASSERTS`
- Fix `BREAKPOINT` making potentially importable assumptions about builtin availability and switched to prefer `__builtin_trap` over a dialect-dependent `asm` intrin on x86. In general this behaviour should likely be made toolchain dependent instead of system dependent - i.e. `__has_builtin`, `_MSC_VER` and `__GNUC__`
- Fix assumption that `ma_uint64` is the same type as `uint64_t` in out-parameters